### PR TITLE
add missing instrument_*.h files to liblsdj install list

### DIFF
--- a/liblsdj/CMakeLists.txt
+++ b/liblsdj/CMakeLists.txt
@@ -14,4 +14,4 @@ set_target_properties(liblsdj PROPERTIES OUTPUT_NAME lsdj)
 source_group(\\ FILES ${HEADERS} ${SOURCES})
 
 install(TARGETS liblsdj DESTINATION lib)
-install(FILES chain.h channel.h command.h error.h groove.h instrument.h sav.h panning.h phrase.h project.h row.h song.h synth.h table.h wave.h word.h vio.h DESTINATION include/lsdj)
+install(FILES chain.h channel.h command.h error.h groove.h instrument.h instrument_constants.h instrument_kit.h instrument_noise.h instrument_pulse.h instrument_wave.h panning.h phrase.h project.h row.h sav.h song.h synth.h table.h vio.h wave.h word.h DESTINATION include/lsdj)


### PR DESCRIPTION
instrument.h includes instrument_kit.h, instrument_noise.h, instrument_pulse.h, and instrument_wave.h, and all of those headers include instrument_constants.h.

Added those headers to the liblsdj CMakeLists.txt header install list, and alphabetized that list.