### PR TITLE
Add option to skip the song in working memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ LibLSDJ is open source and freely available to anyone. If you'd like to show you
 	  -i [ --index ] arg       Single out a given project index to export, 0 or 
 	                           more
 	  -n [ --name ] arg        Single out a given project by name to export
-	  -w [ --working-memory ]  Single out the working-memory song to expor
+	  -w [ --working-memory ]  Single out the working-memory song to export
+	  --skip-working           Do not export the song in working memory when no other projects are given
 
 ## lsdsng-import
 

--- a/lsdsng_export/exporter.cpp
+++ b/lsdsng_export/exporter.cpp
@@ -55,9 +55,7 @@ namespace lsdj
         
         const auto outputFolder = ghc::filesystem::absolute(output);
         
-        // If no specific indices were given, or -w was flagged (index == -1),
-        // display the working memory song as well
-        if ((indices.empty() && names.empty()) || std::find(std::begin(indices), std::end(indices), -1) != std::end(indices))
+        if (shouldExportWorkingMemory())
         {
             lsdj_project_t* project = lsdj_project_new_from_working_memory_song(sav, &error);
             if (error)
@@ -194,9 +192,7 @@ namespace lsdj
             std::cout << "Ver    ";
         std::cout << "Fmt    BPM" << std::endl;
         
-        // If no specific indices were given, or -w was flagged (index == -1),
-        // display the working memory song as well
-        if ((indices.empty() && names.empty()) || std::find(std::begin(indices), std::end(indices), -1) != std::end(indices))
+        if (shouldExportWorkingMemory())
         {
             printWorkingMemorySong(sav);
         }
@@ -371,6 +367,17 @@ namespace lsdj
         std::cout << std::endl;
     }
     
+    bool Exporter::shouldExportWorkingMemory()
+    {
+        // No specific indices were given, export working memory based on --skip-working
+        if (indices.empty() && names.empty())
+        {
+            return !skipWorkingMemory;
+        }
+        // Export based on -w or --index -1
+        return std::find(std::begin(indices), std::end(indices), -1) != std::end(indices);
+    }
+
     std::string Exporter::constructName(const lsdj_project_t* project)
     {
         return constructProjectName(project, underscore);

--- a/lsdsng_export/exporter.hpp
+++ b/lsdsng_export/exporter.hpp
@@ -66,6 +66,7 @@ namespace lsdj
         bool underscore = false;
         bool putInFolder = false;
         bool verbose = false;
+        bool skipWorkingMemory = false;
         
         std::vector<int> indices;
         std::vector<std::string> names;
@@ -73,6 +74,7 @@ namespace lsdj
     private:
         int printFolder(const ghc::filesystem::path& path);
         int printSav(const ghc::filesystem::path& path);
+        bool shouldExportWorkingMemory();
         
     private:
         // Converts a project version to a string representation using the current VersionStyle

--- a/lsdsng_export/main.cpp
+++ b/lsdsng_export/main.cpp
@@ -68,7 +68,8 @@ int main(int argc, char* argv[])
     auto index = options.add<popl::Value<int>>("i", "index", "Single out a given project index to export, 0 or more");
     auto name = options.add<popl::Value<std::string>>("n", "name", "Single out a given project by name to export");
     auto wm = options.add<popl::Switch>("w", "working-memory", "Single out the working-memory song to export");
-    
+    auto skipWorkingMemory = options.add<popl::Switch>("", "skip-working", "Do not export the song in working-memory when no other projects are given");
+
     try
     {
         options.parse(argc, argv);
@@ -89,6 +90,13 @@ int main(int argc, char* argv[])
                 std::cerr << "Path '" << path.string() << "' does not exist" << std::endl;
                 return 1;
             }
+
+            // Find conflicting arguments
+            if (wm->is_set() && skipWorkingMemory->is_set())
+            {
+                std::cerr << "Incompatible arguments: --working-memory and --skip-working";
+                return 1;
+            }
             
             // Create the exporter, that will do the work
             lsdj::Exporter exporter;
@@ -98,7 +106,8 @@ int main(int argc, char* argv[])
             exporter.underscore = underscore->is_set();
             exporter.putInFolder = folder->is_set();
             exporter.verbose = verbose->is_set();
-            
+            exporter.skipWorkingMemory = skipWorkingMemory->is_set();
+
             // Has the user specified one or more specific indices to export?
             if (index->is_set())
             {


### PR DESCRIPTION
Added the option `--skip-working` to skip the song in working memory when the project is unspecified.

Let me know if you'd like the argument to be called something else. `--skip-wm` seemed too vague and `--skip-working-memory` seemed too long. I didn't add a short form because it seems hard to capture the meaning in a single character (`-s` also seems too vague).

The program fails when both `--working-memory` is given and `--skip-working` because it feels like that behaviour should explicitly be undefined. `-i -1` does not fail because `--name` and `--index` both cause the option to be ignored.

Related to #65 