### PR TITLE
fix: add #include <algorithm>

### DIFF
--- a/lsdsng_export/exporter.cpp
+++ b/lsdsng_export/exporter.cpp
@@ -40,6 +40,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <algorithm>
 
 #include <lsdj/sav.h>
 #include <lsdj/song.h>


### PR DESCRIPTION
compiling on Alpine Linux, I hit the following error:

```
[18/47] Building CXX object liblsdj/test/CMakeFiles/test.dir/main.cpp.o
ninja: job failed: /usr/bin/c++  -I/home/domi/projects/libLSDJ/dependency -I/home/domi/projects/libLSDJ/liblsdj/include -std=gnu++20 -MD -MT lsdsng_export/CMakeFiles/lsdsng-export.dir/exporter.cpp.o -MF lsdsng_export/CMakeFiles/lsdsng-export.dir/exporter.cpp.o.d -o lsdsng_export/CMakeFiles/lsdsng-export.dir/exporter.cpp.o -c /home/domi/projects/libLSDJ/lsdsng_export/exporter.cpp
/home/domi/projects/libLSDJ/lsdsng_export/exporter.cpp: In member function 'int lsdj::Exporter::exportSav(const std::filesystem::__cxx11::path&)':
/home/domi/projects/libLSDJ/lsdsng_export/exporter.cpp:110:38: error: no matching function for call to 'find(std::vector<int>::iterator, std::vector<int>::iterator, int&)'
  110 |     if (!indices.empty() && std::find(std::begin(indices), std::end(indices),
      |                             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  111 |                                       i) == std::end(indices))
      |                                       ~~
```

cmake invoked with `cmake -Bbuild -Gninja`; build invoked with `ninja`. Not unlikely that it wasn't visible with classic `make`.