### PR TITLE
skip corrupted projects when extracting SAVs

### DIFF
--- a/liblsdj/src/sav.c
+++ b/liblsdj/src/sav.c
@@ -352,7 +352,7 @@ lsdj_error_t decompress_blocks(lsdj_vio_t* rvio, header_t* header, lsdj_project_
             if (result != LSDJ_SUCCESS)
             {
                 lsdj_project_free(project);
-                return false;
+                continue;
             }
             
             assert(writeCounter == LSDJ_SONG_BYTE_COUNT);


### PR DESCRIPTION
skip corrupted projects during extraction instead of aborting

**before:** extraction aborts upon encountering first corrupted project
**after:** corrupted projects skipped, remaining projects extracted

changes `return false` to `continue` when decompression fails.

includes test case verifying that valid projects before and after a corrupted project are successfully extracted while the corrupted project is skipped

thank you for making liblsdj! really helped me sift through old backups more efficiently (especially with this fix) 😄 